### PR TITLE
Add format JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ optional arguments:
   -s [timeout], --search-crt [timeout]  Retrieve subdomains found in crt.sh
   -m, --matching-domain                 Show matching domain name only
   -o OUTPUT, --output OUTPUT            Set output filename
+  -f {json,text}, --format {json,text}  Set output format
   -c {l,s}, --clipboard {l,s}           Copy the output to the clipboard as a
                                         List or a Single string
   -d, --debug                           Set debug enable


### PR DESCRIPTION
## Description

Add JSON output (in terminal and file)

## Tests

Default output:
```shell
╰> python3 getaltname.py microsoft.com                 
118 SAN's found from microsoft.com
——————————————————————————————————
>> appreadiness.com
>> azure.biz
>> azure.net
>> biztalk.org
>> businessreadylicensing.com
>> clientsecurity.com
>> clientsecurity.net
>> clientsecurity.org
>> deployoffice.com
>> developonbingmaps.com
>> embeddedresourceguide.com
>> fuselabs.com
>> gamevoice.com
>> getie.com
>> gigjam.com
>> hololens.com
```

Default output in json format:
```bash
╰> python3 getaltname.py microsoft.com -f json
{"count": 118, "domains": ["microsoft.ua", "mslearning.com", "partnersinlearning.com", "microsoft.cl", "winhec.net", "microsoft.md", "live.com", "azure.net", "vssdk.com", "startupcenter.com", "microsoft.cz", "microsoft.pl", "microsoft.dk", "msdn2.com", "microsoft.lv", "windows.com", "microsoft.cat", "windowsembedded.com", "imaginecup.pl", "windowsdefender.org", "mymicrosoft.com", "microsoftgamestudios.com", "microsoft.ch", "windowsmarketplace.com", "powerpoint.com", "microsoftcloud.com", "microsoft.ge", "microsoft.de", "microsoftbizspark.com", "mysharepointcommunity.com", "gigjam.com", "microsoft.band", "microsoftband.com", "microsoftwindows.com", "microsoft.es", "msdnmag.com", "windows.biz", "microsoft.jp", "windowsembeddedpartners.com", "msdngeekspeak.com", "embeddedresourceguide.com", "businessreadylicensing.com", "developonbingmaps.com", "microsoft.rs", "microsoftlinc.com", "mslearning.org", "hololens.com", "windowspowershell.org", "microsoftedge.com", "winhec.com", "microsoft.ee", "getie.com", "microsoft.it", "microsoftitacademy.com", "msdntv.com", "microsoft.is", "partnerguide.com", "vort-ex.com", "sharepoint.net", "powerpointlive.com", "sharepointpedia.com", "windowsmobilepartnerspotlight.com", "clientsecurity.net", "officewebapp.com", "msdn.com", "windowsdefender.com", "windowsembeddedpartner.com", "microsoft.pt", "myservice.xbox.com", "appreadiness.com", "macoffice.com", "microsoft.lt", "microsoft.hu", "microsoftdynamics.com", "windowsmobile.com", "azure.biz", "hyper-v.com", "microsoft.be", "microsoft.eu", "deployoffice.com", "windows.nl", "biztalk.org", "microsoft.az", "microsofthealth.com", "microsoft.by", "microsoftlearning.net", "microsoft.si", "microsoft.ru", "mobilepcpartners.com", "microsoft.com", "lastdeveloper.com", "sysinternals.com", "msdnwiki.com", "microsoft.uz", "scriptjunkie.com", "clientsecurity.com", "microsoft.vn", "microsoft.fi", "microsoft.tv", "gamevoice.com", "microsoft.se", "clientsecurity.org", "fuselabs.com", "mssharepointcommunity.com", "windowsdefender.net", "xbox.com", "powerpointradio.com", "microsoft.ca", "microsoft.gr", "microsoft.ro", "mywindowsmobile.com", "surface.com", "microsoftsurface.com", "microsoftlearning.org", "netfx.com", "retailexperiencecenter.com", "microsoft.lu", "windowscatalog.com"]}
```

Output file default:
```bash
╰> python3 getaltname.py microsoft.com -o microsoft.com.out 2>&1 >/dev/null
╰> cat microsoft.com.out 
microsoft.es
microsoft.ee
lastdeveloper.com
microsoft.rs
windowsmobilepartnerspotlight.com
winhec.net
powerpointradio.com
live.com
...
```

Output file json:
```bash
╰> python3 getaltname.py microsoft.com -o microsoft.com.out -f json 2>&1 >/dev/null
╰> cat microsoft.com.out 
{"count": 118, "domains": ["surface.com", "microsoft.dk", "microsoft.ru", "vssdk.com", "windows.biz", "powerpoint.com", "microsoft.de", "windowsembeddedpartners.com", "embeddedresourceguide.com", "microsoftgamestudios.com", "microsoftedge.com", "microsoft.ch", "microsoft.ca", "microsoft.it", "microsoft.es", "live.com", "winhec.net", "microsoftlearning.net", "microsoft.ee", "microsoft.fi", "microsoft.az", "microsoft.by", "mssharepointcommunity.com", "microsoft.hu", "microsoft.ge", "microsoft.pt", "msdn.com", "sysinternals.com", "microsoft.cz", "windowsembedded.com", "windowsmobile.com", "microsoft.tv", "windowsdefender.org", "microsoft.se", "appreadiness.com", "sharepoint.net", "partnersinlearning.com", "microsoftlinc.com", "retailexperiencecenter.com", "windows.com", "msdntv.com", "partnerguide.com", "hololens.com", "sharepointpedia.com", "myservice.xbox.com", "microsoft.uz", "microsoft.si", "microsoftlearning.org", "getie.com", "windowsdefender.net", "businessreadylicensing.com", "msdn2.com", "mywindowsmobile.com", "hyper-v.com", "microsoft.band", "developonbingmaps.com", "microsoft.vn", "vort-ex.com", "imaginecup.pl", "mslearning.org", "fuselabs.com", "winhec.com", "windowspowershell.org", "microsoftdynamics.com", "mymicrosoft.com", "officewebapp.com", "xbox.com", "mysharepointcommunity.com", "powerpointlive.com", "clientsecurity.com", "scriptjunkie.com", "powerpointradio.com", "microsoftwindows.com", "netfx.com", "msdnmag.com", "deployoffice.com", "microsoft.pl", "microsoft.gr", "microsoft.md", "microsoft.eu", "microsoft.ua", "microsoft.lu", "azure.biz", "microsoft.rs", "microsoftitacademy.com", "gamevoice.com", "azure.net", "microsofthealth.com", "microsoft.cl", "msdnwiki.com", "microsoftband.com", "microsoft.is", "microsoft.lt", "windowsmobilepartnerspotlight.com", "windowsmarketplace.com", "clientsecurity.org", "microsoft.be", "windows.nl", "microsoft.ro", "msdngeekspeak.com", "macoffice.com", "microsoft.cat", "windowsdefender.com", "clientsecurity.net", "gigjam.com", "microsoftsurface.com", "windowscatalog.com", "mobilepcpartners.com", "microsoftcloud.com", "windowsembeddedpartner.com", "biztalk.org", "mslearning.com", "microsoftbizspark.com", "startupcenter.com", "microsoft.com", "lastdeveloper.com", "microsoft.lv", "microsoft.jp"]}
```