### PR TITLE
Allow hyphen in hostnames

### DIFF
--- a/gsan/extract_host_port.py
+++ b/gsan/extract_host_port.py
@@ -3,7 +3,7 @@ import re
 
 def parse_host_port(host_string):
     """Parse host:port into a tuple."""
-    regex = re.compile(r"(\[[:a-fA-F0-9]+\]|(?:\d{1,3}\.){3}\d{1,3}|[a-zA-Z0-9.]+)(?::(\d+))?", re.X)
+    regex = re.compile(r"(\[[:a-fA-F0-9]+\]|(?:\d{1,3}\.){3}\d{1,3}|[a-zA-Z0-9-.]+)(?::(\d+))?", re.X)
     m = regex.match(host_string)
     addr, port = m.group(1, 2)
     try:


### PR DESCRIPTION
Hello,

I noticed that gsan did not allow `-` in hostnames, but this character is allowed by RFC. 

Cheers,
Cedric