### PR TITLE
fix(output): --format json --output writes the file (+ UTF-8, no Rich markup on machine output)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,8 @@ indent-style = "space"
 
 [tool.pyright]
 typeCheckingMode = "strict"
+
+[dependency-groups]
+dev = [
+    "pytest>=8",
+]

--- a/src/gsan/output/formatter.py
+++ b/src/gsan/output/formatter.py
@@ -2,8 +2,6 @@
 
 import json
 
-from rich import print as rprint
-
 
 def output_results(
     results: dict[str, list[str]],
@@ -22,8 +20,18 @@ def output_results(
     """
     if output_format == "json":
         output_data = {"results": results, "failed_domains": failed_domains}
-        rprint(json.dumps(output_data, indent=2))
+        json_output = json.dumps(output_data, indent=2)
+        # Machine-readable output must bypass Rich: its console markup would
+        # strip bracketed substrings (e.g. a SAN like "[::1]") and its
+        # soft-wrapping could inject newlines into long lines -- either would
+        # corrupt the emitted JSON. Honour --output for JSON too (previously
+        # the file was never written for the json format).
+        if output_file:
+            with open(output_file, "w", encoding="utf-8") as f:
+                f.write(f"{json_output}\n")
+        else:
+            print(json_output)
     elif output_file:
-        with open(output_file, "w") as f:
+        with open(output_file, "w", encoding="utf-8") as f:
             for subdomains in results.values():
                 f.writelines(f"{subdomain}\n" for subdomain in subdomains)

--- a/tests/test_output_results.py
+++ b/tests/test_output_results.py
@@ -1,0 +1,49 @@
+"""Characterization tests for ``output_results``.
+
+Pin three behaviours corrected in this change:
+- ``--format json --output FILE`` now writes the JSON to the file (previously
+  the json branch printed to the console and never touched the file);
+- machine-readable JSON is emitted verbatim, without Rich console markup
+  mangling bracketed substrings;
+- files are written with an explicit UTF-8 encoding.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gsan.output.formatter import output_results
+
+_RESULTS = {"example.com": ["a.example.com", "[bracketed].example.com"]}
+_FAILED = ["down.example.com"]
+
+
+def test_json_output_is_written_to_file(tmp_path: Path) -> None:
+    """JSON format honours --output and writes parseable JSON to the file."""
+    out = tmp_path / "results.json"
+    output_results(_RESULTS, _FAILED, "json", str(out))
+
+    assert out.exists(), "json + --output must write the file"
+    loaded = json.loads(out.read_text(encoding="utf-8"))
+    assert loaded == {"results": _RESULTS, "failed_domains": _FAILED}
+
+
+def test_json_to_stdout_is_plain_and_parseable(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """JSON to the console is emitted verbatim, brackets intact, and parses."""
+    output_results(_RESULTS, _FAILED, "json", None)
+
+    stdout = capsys.readouterr().out
+    assert "[bracketed].example.com" in stdout, "Rich markup must not strip '[...]'"
+    assert json.loads(stdout) == {"results": _RESULTS, "failed_domains": _FAILED}
+
+
+def test_txt_output_written_to_file(tmp_path: Path) -> None:
+    """Text format writes one subdomain per line to the file."""
+    out = tmp_path / "results.txt"
+    output_results(_RESULTS, _FAILED, "txt", str(out))
+
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert lines == ["a.example.com", "[bracketed].example.com"]

--- a/uv.lock
+++ b/uv.lock
@@ -124,6 +124,11 @@ dependencies = [
     { name = "typer" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "cryptography" },
@@ -131,6 +136,18 @@ requires-dist = [
     { name = "pyopenssl" },
     { name = "rich" },
     { name = "typer" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8" }]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -152,6 +169,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -191,6 +226,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/80/be/97b83a464498a79103036bc74d1038df4a7ef0e402cfaf4d5e113fb14759/pyopenssl-25.3.0.tar.gz", hash = "sha256:c981cb0a3fd84e8602d7afc209522773b94c1c2446a3c710a75b06fe1beae329", size = 184073, upload-time = "2025-09-17T00:32:21.037Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/81/ef2b1dfd1862567d573a4fdbc9f969067621764fbb74338496840a1d2977/pyopenssl-25.3.0-py3-none-any.whl", hash = "sha256:1fda6fc034d5e3d179d39e59c1895c9faeaf40a79de5fc4cbbfbe0d36f4a77b6", size = 57268, upload-time = "2025-09-17T00:32:19.474Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Part of the **dream-2026-07-05.1** audit. Umbrella: #40.

## Three defects in `output_results` (all in `src/gsan/output/formatter.py`)

1. **`--format json --output FILE` silently wrote nothing.** The `json` branch printed to the console and returned before the `elif output_file:` branch, so `gsan example.com --format json --output results.json` produced an **empty/absent file**. Now the JSON is written to the file when `--output` is given.
2. **Machine output was routed through Rich markup.** `rprint(json.dumps(...))` interprets `[...]` substrings as console markup — a SAN like `[::1]` or any bracketed value would be silently stripped, and Rich soft-wrapping could inject newlines into long lines, corrupting the JSON. Machine output now uses plain `print()`.
3. **Files were opened without an explicit encoding**, defaulting to the platform locale encoding. Both write paths now use `encoding="utf-8"`.

## Proof
- `tests/test_output_results.py`: JSON is written to `--output` and round-trips; JSON to stdout keeps `[bracketed]` intact and parses; txt output still writes one subdomain per line.
- ✅ `uv run pytest` (3 passed) · ✅ ruff · ✅ basedpyright (0 errors) · ✅ compileall

Behaviour change worth noting for review: `--format json --output FILE` now writes to the file and prints nothing to the console (previously it printed and ignored the file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
