### PR TITLE
fix(output): escape untrusted certificate SANs in console output

### DIFF
--- a/src/gsan/processing/domain.py
+++ b/src/gsan/processing/domain.py
@@ -4,6 +4,7 @@ import ssl
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from rich import print as rprint
+from rich.markup import escape
 from rich.progress import track
 
 from gsan.certificate.retrieval import allow_unsigned_certificate, get_certificate
@@ -41,9 +42,12 @@ def process_domain(
             return None
 
         if print_results:
-            rprint(f"\n[bold green]{domain}[/bold green] [{len(subdomains)}]:")
+            # Escape cert-derived values: a SAN containing "[...]" would
+            # otherwise be parsed as Rich console markup and silently dropped
+            # (or raise MarkupError on malformed tags like "[/]").
+            rprint(f"\n[bold green]{escape(domain)}[/bold green] [{len(subdomains)}]:")
             for subdomain in subdomains:
-                rprint(f"- {subdomain}")
+                rprint(f"- {escape(subdomain)}")
 
         return domain, subdomains, None
     except Exception as e:

--- a/tests/test_console_markup.py
+++ b/tests/test_console_markup.py
@@ -1,0 +1,89 @@
+"""Characterization test for escaping untrusted SANs in console output.
+
+gsan targets untrusted / self-signed hosts, so certificate SAN values are
+attacker-controlled. A SAN containing Rich markup metacharacters (square
+brackets) must be printed literally, not interpreted as console markup and
+silently dropped. This drives ``process_domain`` end-to-end with a stubbed
+certificate carrying a bracketed SAN.
+"""
+
+import datetime
+from collections.abc import Callable
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import Encoding
+from cryptography.x509.oid import NameOID
+from OpenSSL import crypto
+
+from gsan.certificate.retrieval import allow_unsigned_certificate
+from gsan.processing import domain as domain_module
+
+
+def _cert_with_sans(dns_names: list[str]) -> crypto.X509:
+    """Build a self-signed pyOpenSSL cert carrying ``dns_names`` as SANs.
+
+    Args:
+        dns_names: DNS names to embed in the SubjectAlternativeName extension.
+
+    Returns:
+        A loaded pyOpenSSL X.509 certificate.
+
+    """
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test.example.com")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime(2020, 1, 1))
+        .not_valid_after(datetime.datetime(2035, 1, 1))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.DNSName(n) for n in dns_names]),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    return crypto.load_certificate(
+        crypto.FILETYPE_ASN1, cert.public_bytes(Encoding.DER)
+    )
+
+
+def _returns_cert(cert: crypto.X509) -> Callable[..., crypto.X509]:
+    """Build a typed stand-in for get_certificate that always returns ``cert``.
+
+    Args:
+        cert: The certificate the stub should return.
+
+    Returns:
+        A callable matching get_certificate's shape.
+
+    """
+
+    def _stub(*_args: object, **_kwargs: object) -> crypto.X509:
+        return cert
+
+    return _stub
+
+
+def test_bracketed_san_is_printed_literally(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A SAN containing '[...]' appears verbatim rather than being stripped."""
+    cert = _cert_with_sans(["a.example.com", "evil[bold].example.com"])
+    monkeypatch.setattr(domain_module, "get_certificate", _returns_cert(cert))
+
+    result = domain_module.process_domain(
+        "test.example.com", 443, 1.0, allow_unsigned_certificate(), True
+    )
+
+    assert result is not None
+    stdout = capsys.readouterr().out
+    assert "evil[bold].example.com" in stdout, (
+        "bracketed SAN must be escaped, not parsed as Rich markup"
+    )


### PR DESCRIPTION
Part of the **dream-2026-07-05.1** audit. Umbrella: #40.

## What
`process_domain` interpolates **attacker-controlled certificate SAN values** directly into Rich `print` f-strings (`src/gsan/processing/domain.py:44-46`). Because Rich parses `[...]` as console markup:
- a SAN like `evil[bold].example.com` is **silently stripped** to `evil.example.com` in the output — misreporting what the certificate actually contains, which matters for a recon tool;
- a malformed tag such as a SAN containing `[/]` raises `rich.errors.MarkupError`, aborting the print.

gsan connects to untrusted / self-signed / internal hosts by design, so SAN values must be treated as untrusted. This wraps the cert-derived `domain` and each `subdomain` in `rich.markup.escape()` so they render verbatim while the intentional `[bold green]` styling is preserved.

## Proof
- `tests/test_console_markup.py` drives `process_domain` end-to-end with a stubbed certificate whose SAN contains `evil[bold].example.com`, and asserts the bracketed value appears verbatim in stdout (fails on the unpatched code, passes after the fix).
- ✅ `uv run pytest` (1 passed) · ✅ ruff · ✅ basedpyright (0 errors) · ✅ compileall

Companion to the output-formatter PR (which fixes the same markup hazard on the machine-readable JSON path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
