### PR TITLE
fix(cli): robust host:port parsing (IPv6 literals + invalid ports)

### DIFF
--- a/src/gsan/cli/interface.py
+++ b/src/gsan/cli/interface.py
@@ -1,6 +1,7 @@
 """CLI interface for GSAN."""
 
 from typing import Annotated
+from urllib.parse import urlsplit
 
 import typer
 
@@ -8,6 +9,39 @@ from gsan.output.formatter import output_results
 from gsan.processing.domain import process_domains
 
 app = typer.Typer(add_completion=False)
+
+DEFAULT_PORT = 443
+
+
+def parse_domain(domain: str) -> tuple[str, int]:
+    """Parse a ``host`` or ``host:port`` target into a ``(host, port)`` pair.
+
+    Uses :func:`urllib.parse.urlsplit`, so bracketed IPv6 literals such as
+    ``[2001:db8::1]:443`` and bare hostnames are handled without crashing on
+    the extra colons. When no port is given, :data:`DEFAULT_PORT` is used.
+
+    Args:
+        domain: A target of the form ``host`` or ``host:port``.
+
+    Returns:
+        A ``(host, port)`` tuple with the host string and integer port.
+
+    Raises:
+        ValueError: If the host is missing or the port is not a valid integer
+            in the range 0-65535.
+
+    """
+    split = urlsplit(f"//{domain}")
+    host = split.hostname
+    if not host:
+        msg = f"Could not parse a host from {domain!r}"
+        raise ValueError(msg)
+    try:
+        port = split.port
+    except ValueError:
+        msg = f"Invalid port in {domain!r}"
+        raise ValueError(msg) from None
+    return host, port if port is not None else DEFAULT_PORT
 
 
 @app.command()
@@ -35,16 +69,17 @@ def main(
         typer.Option("--output", help="File to write the results to"),
     ] = None,
 ) -> None:
-    """Check subdomains and IPs present in SSL certificates of specified domains."""
-    parsed_domains: list[tuple[str, int]] = []
-    for domain in domains:
-        if ":" in domain:
-            host, port_str = domain.split(":")
-            port = int(port_str)
-        else:
-            host = domain
-            port = 443  # default port
-        parsed_domains.append((host, port))
+    """Check subdomains and IPs present in SSL certificates of specified domains.
+
+    Raises:
+        typer.BadParameter: If a target cannot be parsed into a host and a
+            valid port.
+
+    """
+    try:
+        parsed_domains = [parse_domain(domain) for domain in domains]
+    except ValueError as error:
+        raise typer.BadParameter(str(error)) from error
 
     print_results = not output_file
     results, failed_domains = process_domains(

--- a/tests/test_parse_domain.py
+++ b/tests/test_parse_domain.py
@@ -1,0 +1,50 @@
+"""Characterization tests for host:port target parsing.
+
+The previous ``domain.split(":")`` + unguarded ``int(...)`` crashed with an
+unhandled traceback on IPv6 literals and malformed ports. ``parse_domain``
+handles bracketed IPv6 and reports bad input as a ``typer.BadParameter``.
+"""
+
+import pytest
+from typer.testing import CliRunner
+
+from gsan.cli.interface import DEFAULT_PORT, app, parse_domain
+
+
+def test_host_only_uses_default_port() -> None:
+    """A bare host resolves to the default HTTPS port."""
+    assert parse_domain("example.com") == ("example.com", DEFAULT_PORT)
+
+
+def test_host_with_explicit_port() -> None:
+    """An explicit port is parsed as an integer."""
+    assert parse_domain("example.com:8443") == ("example.com", 8443)
+
+
+def test_bracketed_ipv6_without_port() -> None:
+    """A bracketed IPv6 literal parses without crashing on inner colons."""
+    assert parse_domain("[2001:db8::1]") == ("2001:db8::1", DEFAULT_PORT)
+
+
+def test_bracketed_ipv6_with_port() -> None:
+    """A bracketed IPv6 literal with a port keeps host and port separate."""
+    assert parse_domain("[2001:db8::1]:8443") == ("2001:db8::1", 8443)
+
+
+def test_non_numeric_port_raises_valueerror() -> None:
+    """A non-numeric port is rejected rather than crashing on int()."""
+    with pytest.raises(ValueError, match="Invalid port"):
+        parse_domain("example.com:https")
+
+
+def test_out_of_range_port_raises_valueerror() -> None:
+    """A port outside 0-65535 is rejected."""
+    with pytest.raises(ValueError, match="Invalid port"):
+        parse_domain("example.com:99999")
+
+
+def test_cli_reports_bad_port_without_traceback() -> None:
+    """Invalid input exits non-zero via BadParameter, not an uncaught crash."""
+    result = CliRunner().invoke(app, ["example.com:https"])
+    assert result.exit_code != 0
+    assert result.exception is None or isinstance(result.exception, SystemExit)


### PR DESCRIPTION
Part of the **dream-2026-07-05.1** audit. Umbrella: #40.

## What
CLI target parsing at `src/gsan/cli/interface.py:41-46` did:
```python
if ":" in domain:
    host, port_str = domain.split(":")
    port = int(port_str)
```
This crashes with an **unhandled traceback** on:
- **IPv6 literals** (`[2001:db8::1]:443` or a bare `2001:db8::1`) — `split(":")` returns more than two parts → `ValueError: too many values to unpack`;
- **malformed ports** (`example.com:https`, `example.com:99999`) — unguarded `int()` / out-of-range.

Replaced with a `parse_domain()` helper built on `urllib.parse.urlsplit(f"//{domain}")`, which correctly separates host and port for bracketed IPv6 and bare hosts, validates the port range, and surfaces bad input as a clean `typer.BadParameter` (exit code, no traceback).

## Proof
- `tests/test_parse_domain.py`: host-only default port, `host:port`, bracketed IPv6 with/without port, non-numeric and out-of-range ports raising, and a CLI-level test that bad input exits non-zero without an uncaught exception.
- ✅ `uv run pytest` (7 passed) · ✅ ruff · ✅ basedpyright (0 errors) · ✅ compileall

Note: bare (unbracketed) IPv6 like `2001:db8::1` is intentionally rejected as ambiguous with `host:port` — IPv6 targets must be bracketed, matching URL conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
