### PR TITLE
fix(extraction): decode IP-address SANs (crash) + deterministic output ordering

### DIFF
--- a/src/gsan/processing/extraction.py
+++ b/src/gsan/processing/extraction.py
@@ -15,13 +15,13 @@ def clean_domains(domains: list[str]) -> list[str]:
         domains: List of domain names to clean.
 
     Returns:
-        Deduplicated list of cleaned domain names.
+        Sorted, deduplicated list of cleaned domain names.
 
     """
     cleaned_domains = {
         domain.removeprefix("*.").removeprefix("www.") for domain in domains
     }
-    return list(cleaned_domains)
+    return sorted(cleaned_domains)
 
 
 def extract_subdomains(x509: crypto.X509) -> list[str]:
@@ -52,8 +52,14 @@ def extract_subdomains(x509: crypto.X509) -> list[str]:
                             if "dNSName" in component:
                                 subdomains.append(str(component.getComponent()))  # type: ignore[attr-defined]
                             elif "iPAddress" in component:
+                                # getComponent() is a pyasn1 OctetString; convert
+                                # to raw bytes so ip_address() sees the packed
+                                # form (4 or 16 bytes) instead of the wrapper
+                                # object, which it cannot parse.
                                 ip_address = str(
-                                    ipaddress.ip_address(component.getComponent())  # type: ignore[attr-defined]
+                                    ipaddress.ip_address(
+                                        bytes(component.getComponent())  # type: ignore[attr-defined]
+                                    )
                                 )
                                 subdomains.append(ip_address)
         return subdomains

--- a/tests/test_extraction_correctness.py
+++ b/tests/test_extraction_correctness.py
@@ -1,0 +1,72 @@
+"""Characterization tests for extraction correctness fixes.
+
+Two defects in ``src/gsan/processing/extraction.py``:
+- IP-address SANs crashed extraction, because a pyasn1 ``OctetString`` was
+  passed straight to ``ipaddress.ip_address()`` instead of its raw bytes
+  (fails identically on pyasn1 0.6.1 and 0.6.3);
+- ``clean_domains`` returned ``list(set(...))``, so output ordering was
+  non-deterministic across runs (bad for a recon tool whose output is diffed
+  and piped). It now returns a sorted list.
+"""
+
+import datetime
+import ipaddress
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import Encoding
+from cryptography.x509.oid import NameOID
+from OpenSSL import crypto
+
+from gsan.processing.extraction import clean_domains, extract_subdomains
+
+
+def _cert_with_sans(sans: list[x509.GeneralName]) -> crypto.X509:
+    """Build a self-signed pyOpenSSL cert carrying ``sans``.
+
+    Args:
+        sans: SubjectAlternativeName entries to embed.
+
+    Returns:
+        A loaded pyOpenSSL X.509 certificate.
+
+    """
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "example.com")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime(2020, 1, 1))
+        .not_valid_after(datetime.datetime(2035, 1, 1))
+        .add_extension(x509.SubjectAlternativeName(sans), critical=False)
+        .sign(key, hashes.SHA256())
+    )
+    return crypto.load_certificate(
+        crypto.FILETYPE_ASN1, cert.public_bytes(Encoding.DER)
+    )
+
+
+def test_ipv4_and_ipv6_sans_are_extracted() -> None:
+    """IP-address SANs are decoded to their string form instead of crashing."""
+    cert = _cert_with_sans(
+        [
+            x509.DNSName("a.example.com"),
+            x509.IPAddress(ipaddress.ip_address("10.0.0.1")),
+            x509.IPAddress(ipaddress.ip_address("2001:db8::1")),
+        ]
+    )
+    assert sorted(extract_subdomains(cert)) == sorted(
+        ["a.example.com", "10.0.0.1", "2001:db8::1"]
+    )
+
+
+def test_clean_domains_is_sorted_and_deduplicated() -> None:
+    """clean_domains strips prefixes, dedupes, and returns a sorted list."""
+    result = clean_domains(
+        ["www.c.example.com", "*.a.example.com", "b.example.com", "a.example.com"]
+    )
+    assert result == ["a.example.com", "b.example.com", "c.example.com"]


### PR DESCRIPTION
Part of the **dream-2026-07-05.1** audit. Umbrella: #40.

Two correctness fixes in `src/gsan/processing/extraction.py`.

## 1. IP-address SANs crashed extraction (found during verification)
`extract_subdomains` passed a pyasn1 `OctetString` **object** straight to `ipaddress.ip_address()`:
```python
ipaddress.ip_address(component.getComponent())
```
`ip_address()` only accepts an int, a string, or **packed bytes** — not the wrapper object — so **any certificate carrying an IP-address SAN raised** `ValueError: ... does not appear to be an IPv4 or IPv6 address`, aborting extraction for that host. IP SANs are common (load balancers, internal hosts, many public certs), so this silently broke a real slice of the tool's targets.

This was **not** caused by the pyasn1 bump — it fails identically on 0.6.1 and 0.6.3. Fix: convert to raw bytes first — `ipaddress.ip_address(bytes(component.getComponent()))`.

## 2. Non-deterministic output ordering
`clean_domains` returned `list(set(...))`, so the order of extracted subdomains changed between runs (Python hash randomization). For a recon tool whose output is diffed across runs and piped into other tools, that's undesirable. Now returns `sorted(...)`.

## Proof
- `tests/test_extraction_correctness.py`: an IPv4+IPv6+DNS certificate now extracts all SANs (previously raised); `clean_domains` output is sorted and deduplicated.
- ✅ `uv run pytest` (2 passed) · ✅ ruff (prek, 0.9.1) · ✅ basedpyright (0 errors) · ✅ compileall

The cryptography.x509 migration PR fixes the IP-SAN bug by construction (its native API returns `IPv4Address`/`IPv6Address`); this PR fixes it for the current pyOpenSSL/pyasn1 code path so it stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
